### PR TITLE
Update documentation links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 amex-jest-preset
 ====================
 
-An opinionated [Jest preset](http://facebook.github.io/jest/docs/configuration.html#preset-string)
+An opinionated [Jest preset](http://facebook.github.io/jest/docs/en/configuration.html#preset-string)
 
 For a React specific Jest preset use: [amex-jest-preset-react](https://github.com/americanexpress/amex-jest-preset-react) which extends off of this preset and adds some React specific configurations.
 
 ## Configurations
-- [setupTestFrameworkScriptFile](http://facebook.github.io/jest/docs/configuration.html#setuptestframeworkscriptfile-string) is where we load [jest-json-schema](https://github.com/americanexpress/jest-json-schema) so you have access to it throughout your tests.
+- [setupTestFrameworkScriptFile](http://facebook.github.io/jest/docs/en/configuration.html#setuptestframeworkscriptfile-string) is where we load [jest-json-schema](https://github.com/americanexpress/jest-json-schema) so you have access to it throughout your tests.
 
 - [testResultsProcessor](http://facebook.github.io/jest/docs/en/configuration.html#testresultsprocessor-string) is used to output test results onto our html report creator. That way pretty html test results are created in `<rootDir>/test-results/`
 
-- [collectCoverage](http://facebook.github.io/jest/docs/configuration.html#collectcoverage-boolean) tells Jest to collect code coverage metrics on every test run
+- [collectCoverage](http://facebook.github.io/jest/docs/en/configuration.html#collectcoverage-boolean) tells Jest to collect code coverage metrics on every test run
 
-- [collectCoverageFrom](http://facebook.github.io/jest/docs/configuration.html#collectcoveragefrom-array) tells Jest what directories to collect and not collect coverage metrics from
+- [collectCoverageFrom](http://facebook.github.io/jest/docs/en/configuration.html#collectcoveragefrom-array) tells Jest what directories to collect and not collect coverage metrics from
 
-- [coverageDirectory](http://facebook.github.io/jest/docs/configuration.html#coveragedirectory-string) tells Jest to output the coverage reports into the `./test-results/coverage` directory
+- [coverageDirectory](http://facebook.github.io/jest/docs/en/configuration.html#coveragedirectory-string) tells Jest to output the coverage reports into the `./test-results/coverage` directory
 
-- [coverageReporters](http://facebook.github.io/jest/docs/configuration.html#coveragereporters-array-string) tells Jest to report coverage as `text` which outputs to your console, `cobertura` format which Jenkins uses, and `lcov` which produces the pretty html you are all used to seeing from Istanbul
+- [coverageReporters](http://facebook.github.io/jest/docs/en/configuration.html#coveragereporters-array-string) tells Jest to report coverage as `text` which outputs to your console, `cobertura` format which Jenkins uses, and `lcov` which produces the pretty html you are all used to seeing from Istanbul
 
-- [coverageThreshold](http://facebook.github.io/jest/docs/configuration.html#coveragethreshold-object) tells Jest to return failure unless code coverage is 100% for branch, function, line, and statement. (Yes this does mean that your build will fail if you don't have 100% code coverage)
+- [coverageThreshold](http://facebook.github.io/jest/docs/en/configuration.html#coveragethreshold-object) tells Jest to return failure unless code coverage is 100% for branch, function, line, and statement. (Yes this does mean that your build will fail if you don't have 100% code coverage)
 
 ## Usage
 
@@ -37,7 +37,7 @@ npm install --save-dev amex-jest-preset
 ```
 And... that's it! You now have all the boilerplate Jest configurations set up for you! Running `jest` from your `npm test` script will use all these configurations!
 
-**Note:** You can override these configurations by [providing your own](http://facebook.github.io/jest/docs/configuration.html) `jest` configuration
+**Note:** You can override these configurations by [providing your own](http://facebook.github.io/jest/docs/en/configuration.html) `jest` configuration
 
 ## Contributing
 We welcome Your interest in the American Express Open Source Community on Github.


### PR DESCRIPTION
The links to the `jest` configuration documentation, except for `testResultsProcessor`, 404. This updates them to point to the English documentation.