### PR TITLE
plainFailureMessage can be null

### DIFF
--- a/html-report-creator.js
+++ b/html-report-creator.js
@@ -79,7 +79,7 @@ module.exports = (result) => {
             test.failureMessages.forEach((failureMsg) => {
               const plainFailureMessage = stripAnsi(failureMsg);
               // TODO: need to find better way to when it is an image snapshot
-              if (plainFailureMessage.includes('__image_snapshots__/')) {
+              if (plainFailureMessage && plainFailureMessage.includes('__image_snapshots__/')) {
                 const imageDiffUrl = `${plainFailureMessage.match(':(.*).png')[1]}.png`;
                 failureMsgDiv.ele('a', { href: imageDiffUrl });
               }


### PR DESCRIPTION
When I ran test on my module, I got the following error:
```bash
TypeError: Cannot read property 'includes' of null
    at test.failureMessages.forEach (/Users/sklawren/Code/amex/gustave/axp-gustave-root/node_modules/amex-jest-preset/html-report-creator.js:82:39)
    at Array.forEach (<anonymous>)
    at suite.testResults.forEach (/Users/sklawren/Code/amex/gustave/axp-gustave-root/node_modules/amex-jest-preset/html-report-creator.js:79:34)
    at Array.forEach (<anonymous>)
    at result.testResults.forEach (/Users/sklawren/Code/amex/gustave/axp-gustave-root/node_modules/amex-jest-preset/html-report-creator.js:70:25)
    at Array.forEach (<anonymous>)
    at module.exports (/Users/sklawren/Code/amex/gustave/axp-gustave-root/node_modules/amex-jest-preset/html-report-creator.js:56:22)
    at processResults (/Users/sklawren/Code/amex/gustave/axp-gustave-root/node_modules/@jest/core/build/runJest.js:259:47)
    at runJest (/Users/sklawren/Code/amex/gustave/axp-gustave-root/node_modules/@jest/core/build/runJest.js:431:10)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
So to prevent this crash from happening, I check to see if plainFailureMessage is truthy.