### PR TITLE
chore(plugins): reorder semantic release plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
-      "@semantic-release/git",
       "@semantic-release/npm",
+      "@semantic-release/git",
       "@semantic-release/github"
     ],
     "branch": "master"


### PR DESCRIPTION
npm needs to be before git so that the git plugin can include it in the commit release